### PR TITLE
fix: doubling "kubectl apply -f"

### DIFF
--- a/practice/4.saving-configurations/2.secret/README.md
+++ b/practice/4.saving-configurations/2.secret/README.md
@@ -52,7 +52,7 @@ kubectl get secret test -o yaml
 # изменяем ключ test на test1
 vim  ~/school-dev-k8s/practice/4.saving-configurations/2.secret/secret.yaml
 
-kubectl apply -f kubectl apply -f ~/school-dev-k8s/practice/4.saving-configurations/2.secret/secret.yaml
+kubectl apply -f ~/school-dev-k8s/practice/4.saving-configurations/2.secret/secret.yaml
 ```
 
 7) Проверяем что в секрете


### PR DESCRIPTION
В описании к практическому занятию 4 часть 2 было задвоение "kubectl apply -f" в пункте " 6. Исправляем манифест секрета и применяем"